### PR TITLE
Fix: compiled mocker.el didn't work

### DIFF
--- a/mocker.el
+++ b/mocker.el
@@ -33,11 +33,12 @@
 
 (require 'eieio)
 
-;; use dflet from el-x if available
-(if (require 'dflet nil t)
-    (defalias 'mocker-flet 'dflet)
-  ;; fallback to regular flet, hoping it's still there
-  (defalias 'mocker-flet 'flet))
+(eval-and-compile
+  ;; use dflet from el-x if available
+  (if (require 'dflet nil t)
+      (defalias 'mocker-flet 'dflet)
+    ;; fallback to regular flet, hoping it's still there
+    (defalias 'mocker-flet 'flet)))
 
 (defvar mocker-mock-default-record-cls 'mocker-record)
 


### PR DESCRIPTION
In the previous version, as mocker-flet was not available at compile
time, expanding this macro failed.
