### PR TITLE
fix handling of :occur 0

### DIFF
--- a/test/mocker-test.el
+++ b/test/mocker-test.el
@@ -268,5 +268,28 @@
    (mocker-let ((f (a b &rest args) ((:input '(1 2 3 4) :output t))))
      (f 1 2 3 4))))
 
+;;; non-regression tests for (:occur 0)
+
+(defun mocker-test-call-foo () (foo))
+
+(defun mocker-test-do-not-call-foo () nil)
+
+(ert-deftest mocker-forbidden-call ()
+  (should-error
+   (mocker-let
+       ((foo () ((:occur 0))))
+     (mocker-test-call-foo))))
+
+(ert-deftest mocker-no-forbidden-call ()
+  (mocker-let
+      ((foo () ((:occur 0))))
+    (mocker-test-do-not-call-foo)))
+
+(ert-deftest mocker-forbidden-full-form ()
+  (should-error
+   (mocker-let
+       ((foo () ((:min-occur 0 :max-occur 0))))
+     (mocker-test-call-foo))))
+
 (provide 'mocker-tests)
 ;;; mocker-tests.el ends here


### PR DESCRIPTION
Two issues at play:
- :min-occur was set to 1 even when :max-occur was set to 0
- mocker-use-record was happily bumping :-occurrences past :-max-occur

We still keep :min-occur defaulting to 1 unless :max-occur (or :occur) is 0. The
rationale being that by default a mock is defined to be used.
And mocker-use-record now checks boundaries, emitting mocker-record-error as
needed.

Add corresponding tests, based on initial report.

This fixes #8