### PR TITLE
Suppress warning when file system functions are being mocked

### DIFF
--- a/mocker.el
+++ b/mocker.el
@@ -358,9 +358,10 @@ specialized mini-languages for specific record classes.
                          mocks)))
     `(let (,@vars)
        ,@inits
-       (prog1
-           ,(macroexpand `(cl-letf (,@specs) ,@body))
-         ,@verifs))))
+       (let ((native-comp-enable-subr-trampolines nil))
+         (prog1
+             ,(macroexpand `(cl-letf (,@specs) ,@body))
+           ,@verifs)))))
 
 (provide 'mocker)
 ;;; mocker.el ends here

--- a/test/mocker-test.el
+++ b/test/mocker-test.el
@@ -291,5 +291,10 @@
        ((foo () ((:min-occur 0 :max-occur 0))))
      (mocker-test-call-foo))))
 
+(ert-deftest trampoline-demo-with-warning ()
+  (mocker-let ((file-exists-p (file) ((:input '("/some/file.txt") :output t))))
+    (should (file-exists-p "/some/file.txt")))
+  (should-not (get-buffer "*Warnings*")))
+
 (provide 'mocker-tests)
 ;;; mocker-tests.el ends here


### PR DESCRIPTION
Fix #12 